### PR TITLE
fix pkg not_found issue

### DIFF
--- a/src/pynqcar_pubsub/package.xml
+++ b/src/pynqcar_pubsub/package.xml
@@ -14,7 +14,7 @@
   
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>sensor_msgs</sensor_msgs>
+  <exec_depend>sensor_msgs</exec_depend>
   
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
修改了package.xml的錯誤 解決了找不到pynqcar_pubsub package的問題